### PR TITLE
Ripple breaks if clientX xor clientY is zero

### DIFF
--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -97,8 +97,8 @@ MaterialRipple.prototype.downHandler_ = function(event) {
       x = Math.round(bound.width / 2);
       y = Math.round(bound.height / 2);
     } else {
-      var clientX = event.clientX ? event.clientX : event.touches[0].clientX;
-      var clientY = event.clientY ? event.clientY : event.touches[0].clientY;
+      var clientX = event.clientX != null ? event.clientX : event.touches[0].clientX;
+      var clientY = event.clientY != null ? event.clientY : event.touches[0].clientY;
       x = Math.round(clientX - bound.left);
       y = Math.round(clientY - bound.top);
     }


### PR DESCRIPTION
Should be checking nullness here, not falsiness, since zero is falsy.  Using double-equals so both null and undefined will work.  Yes, I was able to cause this breakage by clicking with a mouse when I had an element right up against the edge of my screen.  Perhaps the keyboard detection above should be revisited too, in case you click on that one pixel [0,0]
